### PR TITLE
feat: add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+npm-debug.log
+node_modules
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:alpine
+
+ENV YARN_VERSION 1.19.1
+WORKDIR /usr/src/app/
+
+RUN yarn policies set-version $YARN_VERSION
+
+COPY package*.json ./
+
+RUN apk --update upgrade \
+    && apk add --no-cache ca-certificates python make g++ libc6-compat \
+    && yarn --production --ignore-engines
+
+COPY . .
+
+EXPOSE 9191
+
+CMD [ "node", "index.js" ]

--- a/README.md
+++ b/README.md
@@ -16,5 +16,24 @@ Send an email to the clownfish email address with the subject line `${structure}
 ## Overview
 ![Clownfish Overview](./docs/overview.svg "How it works")
 
+## Deploying with Docker
+
+There is a Dockerfile in this repository.  Deploying with Docker is relatively simple.
+
+```sh
+# clone into clownfish dir
+git clone https://github.com/IMA-WorldHealth/clownfish.git clownfish
+
+cd clownfish
+
+# build the docker file.  This will take a while.
+docker build -t <user>/clownfish .
+
+# deploy the docker file locally
+docker run --expose 7171:9191 -d jniles/clownfish
+
+# you can now connect to 127.0.0.1:9191 to connect to the local app instance
+```
+
 ## License
 [MIT](./LICENSE)

--- a/logger.js
+++ b/logger.js
@@ -10,6 +10,8 @@ class Logger {
   constructor(name) {
     this.db = new Database(name || './database.db');
 
+    this.db.pragma('journal_mode = WAL');
+
     const createLoggerTableQuery = `
       CREATE TABLE IF NOT EXISTS logger (
         googleDriveParentFolderId INTEGER,


### PR DESCRIPTION
We've added a Dockerfile that successfully builds and deploys the application.  Just run `docker build -t jniles/clownfish .` and the application will be built locally.