### PR TITLE
[Merged by Bors] - fix(email): ensure support forwarding is set up

### DIFF
--- a/email.js
+++ b/email.js
@@ -50,6 +50,8 @@ async function support(params) {
   }
 
   try {
+    delete params.attachments; // eslint-disable-line
+    delete params.headers; // eslint-disable-line
     await mailer.send(params);
     debug(`Email successfully sent to ${params.to} with SendGrid`);
   } catch (e) {


### PR DESCRIPTION
Fixes a bug where sendgrid would reject certain properties on the support emails.