### PR TITLE
[Merged by Bors] - fix(ci): ensure dependabot commit is parsed

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,9 @@
 status = [
-  "continuous-integration/travis-ci/push",
+  "continuous-integration/travis-ci/push"
 ]
 
-delete_merged_branches = true
 use_squash_merge = true
+
+timeout_sec = 14400
+
+cut_body_after = "</details>"


### PR DESCRIPTION
This commit ensures that the dependabot commit gets parsed out before a
merge to prevent ci-skips and such directives from influencing Travis.